### PR TITLE
Add Instructions for Generating API Client Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # genome-nexus-java-api-client
 Java API Client for [Genome Nexus](https://www.genomenexus.org)
 
-To generate the api client, run:
+The api generation script (`scripts/generateApiClientModules.sh`) defaults to using `http://genomenexus.org/v2/api-docs`. However, the user can override this by passing in an alternate URL as a command line argument.
+
+### Generate API Client Based on Production Genome Nexus
+To generate the api client based on the production Genome Nexus instance, run:
 ```
 . scripts/generateApiClientModules.sh
 ```
 
-The script defaults to using `http://genomenexus.org/v2/api-docs` to generate the api client modules. However, the user can override this by passing in an alternate URL as a command line argument.
-
-Deploy a local Genome Nexus instance using desired codebase and run:
+### Generate API Client Based on Custom Genome Nexus
+To generate the api client based on a custom instance of Genome Nexus, deploy a local Genome Nexus instance using desired codebase and run:
 ```
 . scripts/generateApiClientModules.sh localhost:38080/v2/api-docs
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # genome-nexus-java-api-client
 Java API Client for [Genome Nexus](https://www.genomenexus.org)
 
+To generate the api client, run:
+```
+. scripts/generateApiClientModules.sh
+```
+
+The script defaults to using `http://genomenexus.org/v2/api-docs` to generate the api client modules. However, the user can override this by passing in an alternate URL as a command line argument.
+
+Deploy a local Genome Nexus instance using desired codebase and run:
+```
+. scripts/generateApiClientModules.sh localhost:38080/v2/api-docs
+```
+
 ## Get latest release from jitpack
 [![Release](https://jitpack.io/v/genome-nexus/genome-nexus-java-api-client.svg)](https://jitpack.io/#genome-nexus/genome-nexus-java-api-client)


### PR DESCRIPTION
Added general instructions for updating API Client Modules. 
Made in conjunction with updates to GN Annotation Pipeline docs.

GN Annotation Pipeline PR here: https://github.com/genome-nexus/genome-nexus-annotation-pipeline/pull/131